### PR TITLE
Pass the configured timeout to the DirectBiddingEvent class

### DIFF
--- a/criteo-htb.js
+++ b/criteo-htb.js
@@ -366,7 +366,8 @@ function CriteoHtb(configs) {
                 criteoSlots,
                 demandSuccess,
                 demandError,
-                demandTimeout);
+                demandTimeout,
+                configs.timeout);
 
             /* __requestTimeouts is also used as a flag to check if the callbacks have been called, so it has
                to be set or the callbacks will refuse to fire */


### PR DESCRIPTION
For logging purposes, to have the XHR request cancel properly, and to call the callback at the right time, we need to provide the chosen timeout value to the `DirectBiddingEvent` class or it will default to 3000 ms.